### PR TITLE
Fixing Nimfa/indian-pines/losses issues with the benchmark

### DIFF
--- a/datasets/indian_pines.py
+++ b/datasets/indian_pines.py
@@ -1,29 +1,9 @@
 from pathlib import Path
-
 from benchopt import BaseDataset, safe_import_context
 
 with safe_import_context() as import_ctx:
-    from io import BytesIO
-    from urllib.request import urlopen
-
-    import scipy.io
     import numpy as np
-
-    # Downgrading cryptography is necessary when using OpenSSL3
-    import ssl
-    MAX_CRYPTO_VERSION = None
-    if ssl.OPENSSL_VERSION.startswith("OpenSSL 3"):
-        MAX_CRYPTO_VERSION = "36.0.2"
-        import cryptography
-        if cryptography.__version__ > MAX_CRYPTO_VERSION:
-            raise ImportError(
-                f"Need to downgrade cryptography to {MAX_CRYPTO_VERSION}"
-            )
-
-DATA_URL = "http://ehu.eus/ccwintco/uploads/6/67/Indian_pines_corrected.mat"
-# Put this in `data` folder of the benchmark folder
-DATA_FILE = Path(__file__).parent / "data" / "indian_pines_corrected.npy"
-
+    from tensorly.datasets.data_imports import load_indian_pines 
 
 class Dataset(BaseDataset):
 
@@ -34,14 +14,13 @@ class Dataset(BaseDataset):
     parameters = {
         'm_dim': [200],
         'n_dim': [145 ** 2],
-        'pixel_subsample': [True],
         'true_rank': [4],
         'estimated_rank': [4],
         'random_state': [26],
     }
 
     install_cmd = 'conda'
-    requirements = [f'cryptography{"=36.0.2" if MAX_CRYPTO_VERSION else ""}']
+    requirements = ['pip:tensorly']
 
     def get_data(self):
         '''
@@ -50,30 +29,16 @@ class Dataset(BaseDataset):
         The Signal to Noise ratio is specified by the user.
         '''
 
-        # If the data file does not exist, load it from the web
-        if not DATA_FILE.exists():
-            # We fetch the data locally the web
-            # Code copied from Tensorly import data function,
-            # credits to Caglayan Tuna
-            DATA_FILE.parent.mkdir(exist_ok=True)
-            data = BytesIO(urlopen(DATA_URL).read())
-            Xtensor = scipy.io.loadmat(data)["indian_pines_corrected"]
-            np.save(DATA_FILE, Xtensor)
-
-        Xtensor = np.load(DATA_FILE)
-
-        # Subsampling otherwise it is too big
-        if self.pixel_subsample:
-            self.n_dim = 20**2
-            Xtensor = Xtensor[20:40, 20:40, :]
+        data = load_indian_pines()
+        tensor = data["tensor"]
 
         # Normalization of the data
-        Xtensor = Xtensor/np.linalg.norm(Xtensor)
+        tensor = tensor/np.linalg.norm(tensor)
         # Matricizing into spectra x pixels
-        Xtensor = np.transpose(Xtensor, [2, 1, 0])
-        X = np.reshape(Xtensor, [self.m_dim, self.n_dim])
+        tensor = np.transpose(tensor, [2, 1, 0])
+        tensor = np.reshape(tensor, [self.m_dim, self.n_dim])
 
         # `data` (this output) holds the keyword arguments for the `set_data`
         #  method of the objective.
         # They are customizable.
-        return dict(X=X, rank=self.estimated_rank)
+        return dict(X=tensor, rank=self.estimated_rank)

--- a/log.md
+++ b/log.md
@@ -1,5 +1,19 @@
 ## A few comments on what I found hard/confusion when implementing the benchmark
 
+Sprint July 2023 TODOS:
+-----------------------
+- Benchmark NMF: finish it
+  - compute all losses all the time
+  - fix suboptimal permutation at evaluation with tensorly
+  - add other data (e.g. faces?)
+  - (optional) fix nimfa, add other solvers
+  - (optional) fix scikit-learn +1 iteration being unfair
+
+- Documentation more practical (could need some help):
+  - Tutorial on how to write a benchmark ? (use a simple case like ridge?). Useful for devs to better know how to implement new benchmarks, useful for users who understand how it works and the basic ways to tweak a benchmark. Include a graph of relationship between the methods of classes. Start from template benchmark and add regularization. Add another simulation or a true dataset?
+  - other solution: start from scratch (longer and less robust)
+  - Cheatsheet with common command lines
+
 Sprint November 2022 comments
 --------------------------------
 - cheatcheets/GUIDED examples 

--- a/log.md
+++ b/log.md
@@ -2,16 +2,17 @@
 
 Sprint July 2023 TODOS:
 -----------------------
-- Benchmark NMF: finish it
-  - compute all losses all the time
-  - fix suboptimal permutation at evaluation with tensorly
-  - add other data (e.g. faces?)
-  - (optional) fix nimfa, add other solvers
-  - (optional) fix scikit-learn +1 iteration being unfair
+- Benchmark NMF: finished?
 
 - Documentation more practical (could need some help):
-  - Tutorial on how to write a benchmark ? (use a simple case like ridge?). Useful for devs to better know how to implement new benchmarks, useful for users who understand how it works and the basic ways to tweak a benchmark. Include a graph of relationship between the methods of classes. Start from template benchmark and add regularization. Add another simulation or a true dataset?
+  - Tutorial on how to write a benchmark ? (use a simple case like ridge?). Useful for devs to better know how to implement new benchmarks, useful for users who understand how it works and the basic ways to run and tweak a benchmark. Include a graph of relationship between the methods of classes. Start from template benchmark and add regularization. Add another simulation or a true dataset?
   - other solution: start from scratch (longer and less robust)
+  - other thing: tutorial to reproduce the NMF benchmark, or start a FAQ with the various points raised in the NMF benchmark
+    - shared init -> given by the objective; solver-wise smart init belongs to each solver.
+    - ground truth, provided by the dataset to the objective
+    - several strategies / objectives for each solver, several loss for evaluation
+    - installing packages
+    - 
   - Cheatsheet with common command lines
 
 Sprint November 2022 comments

--- a/log.md
+++ b/log.md
@@ -1,0 +1,30 @@
+## A few comments on what I found hard/confusion when implementing the benchmark
+
+Sprint November 2022 comments
+--------------------------------
+- cheatcheets/GUIDED examples 
+- Explain how benchopt works optimization-wise (doc only says how to code, not what it does; I had to chat with Thomas to understand)
+- Graph for dependencies of functions
+- stopping criterion (goes with understanding) --> hard implementation but examples help.
+
+
+About the general structure
+------------------------------
+
+- A diagramm showing how the three main classes rely on each other (e.g. which method calls depends on which other method's input/output). The cross dependency of methods was confusing to me, and I went back and forth writing inputs/outputs in the wrong places.
+- Explain what each class should do for these particular cases:
+    - Initialization: the runners take care of it; open question: how to share initialization (and not just a random seed?)
+    - hyperparameters can belong to methods (e.g. some stepsize), to objectives (e.g. some regularization parameter) or to the data (e.g. some prior knowledge on the rank in NMF). It would be nice to have a clearer distinction between these stated somewhere, with a discussion on how to handle them.
+- I just can't seem to make the tests pass :( I tried my best though, not sure what is failing
+- I am not sure I like the fact that one run is cut into several calls, which are timed, to build the loss/time curve. Some methods required knowledge of the previous iterations, and cutting the run like this make degrade performances? Why not require the methods to return time? Or at least make sure somehow all the variables are left untouched when chopping the run (maybe this is the case, but it is not clearly explained in the doc?)  ---> we rerun all from the top so this is not an issue (cf comment below on What benchopt does).
+
+
+About the runs
+---------------
+
+- It is still not clear to me how the maximal number of iterations is set. I went deep in benchopt code, and clearly things are happening under the hood to set this maxiter, but I wish it was easier to control the stopping criterion in general? If it is easy, e.g. with the CLI interface, then it is not so clear in the doc.
+     (Note: after writing this I found the -n options in the CLI, with default 100; it is not put forth enough)
+- I did not try it, but I am not sure how to use the tolerance stopping criterion instead of the maximum number of iterations. Should the methods re-implement the loss and compute it themselves to stop?
+- Some instruction for naming the methods would be nice (I realised later that the name matter for calling with the CLI interface)
+- Maybe not a bug, but when I print something right after the definition of run, I get a verbose output with chopped first letter, replaced by my print.
+

--- a/objective.py
+++ b/objective.py
@@ -7,6 +7,7 @@ with safe_import_context() as import_ctx:
     # importing scipy for KL div
     from scipy.special import kl_div
     # Requires Tensorly >=0.8, postpone implementation
+    # TODO
     # import tensorly
     # from tensorly.cp_tensor import cp_normalize, cp_permute_factors
 
@@ -19,7 +20,7 @@ class Objective(BaseObjective):
     # All parameters 'p' defined here are available as 'self.p'
     parameters = {
         'share_init': [True],
-        # TODO: 'all' for all losses simult
+        # TODO: 'all' for all losses simult, should be new default
         # losses will be computed on different runs
         'loss_type': ['frobenius']  # , 'kl']
     }

--- a/objective.py
+++ b/objective.py
@@ -52,7 +52,7 @@ class Objective(BaseObjective):
 
         output_dic = {
             'frobenius': frobenius_loss,
-            'kl': kl_loss, 
+            'kullback-leibler': kl_loss, 
         }
 
         if self.true_factors:

--- a/solvers/apg.py
+++ b/solvers/apg.py
@@ -1,4 +1,5 @@
 from benchopt import BaseSolver, safe_import_context
+from benchopt.stopping_criterion import SufficientProgressCriterion
 
 with safe_import_context() as import_ctx:
     import numpy as np
@@ -14,8 +15,9 @@ class Solver(BaseSolver):
     parameters = {
         'n_inner_iter': [1, 5]
     }
-
-    stopping_strategy = "callback"
+    
+    # TODO: have to append "objective" ^^
+    stopping_criterion = SufficientProgressCriterion(strategy="callback", key_to_monitor="objective_frobenius")
 
     def set_objective(self, X, rank, factors_init):
         # The arguments of this function are the results of the

--- a/solvers/apg.py
+++ b/solvers/apg.py
@@ -13,10 +13,10 @@ class Solver(BaseSolver):
 
     # any parameter defined here is accessible as a class attribute
     parameters = {
-        'n_inner_iter': [1, 5]
+        'n_inner_iter': [1, 5],
+        'loss': ['euclidean']
     }
     
-    # TODO: have to append "objective" ^^
     stopping_criterion = SufficientProgressCriterion(strategy="callback", key_to_monitor="objective_frobenius")
 
     def set_objective(self, X, rank, factors_init):

--- a/solvers/nimfa.py
+++ b/solvers/nimfa.py
@@ -9,7 +9,6 @@ with safe_import_context() as import_ctx:
 class Solver(BaseSolver):
     '''
     MU implementations in nimfa
-    TODO: change loss depending on user input? cf scikit learn
     '''
     name = "nimfa"
 
@@ -25,7 +24,7 @@ class Solver(BaseSolver):
     install_cmd = 'conda'
     requirements = ['pip:nimfa']
     
-    stopping_criterion = SufficientProgressCriterion(strategy="iteration", key_to_monitor="objective_frobenius", patience=20)
+    stopping_criterion = SufficientProgressCriterion(strategy="iteration", key_to_monitor="objective_frobenius")
 
     def skip(self, X, rank, factors_init):
         if self.loss != "euclidean" and self.strategy != "MU":
@@ -55,13 +54,16 @@ class Solver(BaseSolver):
             W = np.copy(self.init[0])
             H = np.copy(self.init[1])
 
+        if n_iter==0:
+            self.factors = [np.array(W), np.array(H)]
+            return
+
         if self.strategy == 'MU':
             nmf = nimfa.Nmf(
                 self.X, rank=self.rank, update=self.loss, max_iter=n_iter,
                 min_residual=0, W=W, H=H, test_conv=0
             )
         elif self.strategy == 'ALS-PG':
-            # TODO: Add inner_sub_iter to parameters ?
             nmf = nimfa.Lsnmf(
                 self.X, rank=self.rank, max_iter=n_iter, sub_iter=self.sub_iter_max,
                 inner_sub_iter=self.sub_iter_max, beta=0.1, W=W, H=H

--- a/solvers/nimfa.py
+++ b/solvers/nimfa.py
@@ -19,8 +19,6 @@ class Solver(BaseSolver):
         'sub_iter_max': [10],
     }
 
-    #stopping_strategy = "iteration"
-
     install_cmd = 'conda'
     requirements = ['pip:nimfa']
     

--- a/solvers/nimfa.py
+++ b/solvers/nimfa.py
@@ -16,14 +16,16 @@ class Solver(BaseSolver):
     # any parameter defined here is accessible as a class attribute
     parameters = {
         'strategy': ['MU', 'ALS-PG'],
-        'loss': ['euclidean']  # Other choices: 'divergence' (for KL)
+        'loss': ['euclidean'],  # Other choices: 'divergence' (for KL)
+        'sub_iter_max': [10],
     }
 
-    stopping_strategy = "iteration"
+    #stopping_strategy = "iteration"
 
     install_cmd = 'conda'
     requirements = ['pip:nimfa']
-    stopping_criterion = SufficientProgressCriterion(patience=20)  # TODO check if fixes issue
+    
+    stopping_criterion = SufficientProgressCriterion(strategy="iteration", key_to_monitor="objective_frobenius", patience=20)
 
     def skip(self, X, rank, factors_init):
         if self.loss != "euclidean" and self.strategy != "MU":
@@ -61,8 +63,8 @@ class Solver(BaseSolver):
         elif self.strategy == 'ALS-PG':
             # TODO: Add inner_sub_iter to parameters ?
             nmf = nimfa.Lsnmf(
-                self.X, rank=self.rank, max_iter=n_iter, sub_iter=10,
-                inner_sub_iter=10, beta=0.1, W=W, H=H
+                self.X, rank=self.rank, max_iter=n_iter, sub_iter=self.sub_iter_max,
+                inner_sub_iter=self.sub_iter_max, beta=0.1, W=W, H=H
             )
         else:
             raise ValueError("Strategy not suported")

--- a/solvers/nimfa.py
+++ b/solvers/nimfa.py
@@ -1,4 +1,5 @@
 from benchopt import BaseSolver, safe_import_context
+from benchopt.stopping_criterion import SufficientProgressCriterion
 
 with safe_import_context() as import_ctx:
     import nimfa
@@ -21,6 +22,7 @@ class Solver(BaseSolver):
 
     install_cmd = 'conda'
     requirements = ['pip:nimfa']
+    stopping_criterion = SufficientProgressCriterion(patience=20)  # TODO check if fixes issue
 
     def skip(self, X, rank, factors_init):
         if self.loss != "euclidean" and self.strategy != "MU":

--- a/solvers/sklearn.py
+++ b/solvers/sklearn.py
@@ -52,7 +52,12 @@ class Solver(BaseSolver):
 
     def run(self, n_iter):
         # sklearn doesn't work with max_iter=0
-        self.clf.max_iter = max(n_iter,1)# + 1
+        if n_iter==0:
+            self.W = self.factors_init[0]
+            self.clf.components_ = self.factors_init[1]
+            return
+        else:
+            self.clf.max_iter = n_iter
 
         if self.clf.init == "custom":
             self.W = self.clf.fit_transform(

--- a/solvers/tensorly.py
+++ b/solvers/tensorly.py
@@ -1,4 +1,5 @@
 from benchopt import BaseSolver, safe_import_context
+from benchopt.stopping_criterion import SufficientProgressCriterion
 
 
 with safe_import_context() as import_ctx:
@@ -6,6 +7,7 @@ with safe_import_context() as import_ctx:
     from tensorly.decomposition._nn_cp import non_negative_parafac
     from tensorly.decomposition._nn_cp import non_negative_parafac_hals
 
+#TODO fix??
 
 class Solver(BaseSolver):
     '''
@@ -18,7 +20,9 @@ class Solver(BaseSolver):
         'strategy': ['MU', 'HALS']
     }
 
-    stopping_strategy = "iteration"
+    stopping_criterion = SufficientProgressCriterion(strategy="iteration", key_to_monitor="objective_frobenius")
+
+    #stopping_strategy = "iteration" TODO: callback ?
 
     install_cmd = 'conda'
     requirements = ['pip:tensorly']

--- a/solvers/tensorly.py
+++ b/solvers/tensorly.py
@@ -7,7 +7,6 @@ with safe_import_context() as import_ctx:
     from tensorly.decomposition._nn_cp import non_negative_parafac
     from tensorly.decomposition._nn_cp import non_negative_parafac_hals
 
-#TODO fix??
 
 class Solver(BaseSolver):
     '''

--- a/solvers/tensorly.py
+++ b/solvers/tensorly.py
@@ -23,8 +23,6 @@ class Solver(BaseSolver):
 
     stopping_criterion = SufficientProgressCriterion(strategy="iteration", key_to_monitor="objective_frobenius")
 
-    #stopping_strategy = "iteration" TODO: callback ?
-
     install_cmd = 'conda'
     requirements = ['pip:tensorly']
 

--- a/solvers/tensorly.py
+++ b/solvers/tensorly.py
@@ -17,7 +17,8 @@ class Solver(BaseSolver):
 
     # any parameter defined here is accessible as a class attribute
     parameters = {
-        'strategy': ['MU', 'HALS']
+        'strategy': ['MU', 'HALS'],
+        'loss': ['euclidean'] 
     }
 
     stopping_criterion = SufficientProgressCriterion(strategy="iteration", key_to_monitor="objective_frobenius")


### PR DESCRIPTION
This PR fixes the following issues:
#10 : we make use of [new functionalities in benchopt](https://github.com/benchopt/benchopt/pull/461) to make the solvers decide which loss is used to track convergence. From the perspective of the objective, all losses (frobenius, kl, factor match score) are computed regardless of the solver.
#7  #9 : Indian pines is now provided in tensorly, so we use tensorly for the import. Much simpler code.
#6 : tensorly 8.0 is now released, so the factor match score computation is using optimal permutations of the factors thanks to scipy linear assignment solver.
#5 : Nimfa was running fully when iter_max=0 was provided. This is now fixed. Scikit-learn also does not run when 0 iterations are requested.